### PR TITLE
Adding ReDoc and implement first approach to deliver a mocked result

### DIFF
--- a/mock_server/api.py
+++ b/mock_server/api.py
@@ -1,11 +1,27 @@
-def bookings_options_get(message):
+import json
+
+
+# TODO - how to cope with optional parameters?
+# TODO - from as Parameter name is not a good choice as the mapping here leads to an invalid code syntax ? 
+# TODO -    how to map parameters in API to handler parameters?
+# - 
+# changed from to fromP because from is a reserved word in Python
+def bookings_options_get(fromP, to, startTime):
     # do something
-    return 'Message: {}'.format(message), 200
+    print("/bookings/options/ GET")
+    return 'Message: {}'.format(to), 200
 
 
+# -----------------
+# /bookings GET
+#
 def bookings_get(state):
     # do something
-    print(state)
+    print("/bookings GET - " + state)
+    with open("./mock_json/mock_data_bookings_get.json", "r") as read_file:
+        json_string = json.load(read_file)
+    #print(json_string)
+    return json_string, 200 
 
 
 def bookings_post(message):

--- a/mock_server/api.py
+++ b/mock_server/api.py
@@ -1,4 +1,5 @@
 import json
+import flask
 
 
 # TODO - how to cope with optional parameters?
@@ -6,7 +7,7 @@ import json
 # TODO -    how to map parameters in API to handler parameters?
 # - 
 # changed from to fromP because from is a reserved word in Python
-def bookings_options_get(fromP, to, startTime):
+def bookings_options_get(_from, to, startTime):
     # do something
     print("/bookings/options/ GET")
     return 'Message: {}'.format(to), 200
@@ -18,6 +19,7 @@ def bookings_options_get(fromP, to, startTime):
 def bookings_get(state):
     # do something
     print("/bookings GET - " + state)
+    # get static, manually defined JSON from a given folder
     with open("./mock_json/mock_data_bookings_get.json", "r") as read_file:
         json_string = json.load(read_file)
     #print(json_string)
@@ -37,3 +39,15 @@ def bookings_id_get(message):
 def bookings_id_put(message):
     # do something
     return 'Message: {}'.format(message), 200
+
+
+# #####################################
+# add static part
+
+# deliver a ReDoc based documentation
+# ReDoc can be found here https://github.com/Rebilly/ReDoc
+# MIT licence
+def static_redoc():
+    print("Deliver redoc")
+    return flask.send_file('redoc.htm')
+    

--- a/mock_server/api.py
+++ b/mock_server/api.py
@@ -1,17 +1,15 @@
 import json
 import flask
 
-
-# TODO - how to cope with optional parameters?
-# TODO - from as Parameter name is not a good choice as the mapping here leads to an invalid code syntax ? 
-# TODO -    how to map parameters in API to handler parameters?
-# - 
-# changed from to fromP because from is a reserved word in Python
-def bookings_options_get(_from, to, startTime):
-    # do something
+# -----------------
+# /bookings/options GET
+# Parameter in: from, to, startTime
+# "from" is mandatory
+ 
+def bookings_options_get(**options):
+    # you can get the parameters by options["from"]
     print("/bookings/options/ GET")
-    return 'Message: {}'.format(to), 200
-
+    return 'Message: {}'.format(options["from"]), 200
 
 # -----------------
 # /bookings GET

--- a/mock_server/app.py
+++ b/mock_server/app.py
@@ -3,6 +3,6 @@ import connexion
 app = connexion.App(__name__, specification_dir='../specifications/')
 app.add_api('booking.yaml')
 app.run(port=8080)
-
+# test
 if __name__ == "__main__":
     app.run()

--- a/mock_server/app.py
+++ b/mock_server/app.py
@@ -1,8 +1,10 @@
 import connexion
 
-app = connexion.App(__name__, specification_dir='../specifications/')
-app.add_api('booking.yaml')
+app = connexion.FlaskApp(__name__, specification_dir='../specifications/')
+app.add_api('booking.yaml', base_path='/booking')
+#app.add_api('maas-api.yaml')
+
 app.run(port=8080)
-# test
+
 if __name__ == "__main__":
     app.run()

--- a/mock_server/app.py
+++ b/mock_server/app.py
@@ -1,7 +1,9 @@
 import connexion
+import flask
 
 app = connexion.FlaskApp(__name__, specification_dir='../specifications/')
-app.add_api('booking.yaml')
+app.add_api('booking.yaml', base_path='/booking')
+app.add_api('staticfile.yaml', base_path='/redoc')
 #app.add_api('maas-api.yaml')
 
 app.run(port=8080)

--- a/mock_server/app.py
+++ b/mock_server/app.py
@@ -1,7 +1,7 @@
 import connexion
 
 app = connexion.FlaskApp(__name__, specification_dir='../specifications/')
-app.add_api('booking.yaml', base_path='/booking')
+app.add_api('booking.yaml')
 #app.add_api('maas-api.yaml')
 
 app.run(port=8080)

--- a/mock_server/mock_json/mock_data_bookings_get.json
+++ b/mock_server/mock_json/mock_data_bookings_get.json
@@ -1,0 +1,96 @@
+[
+    {
+        "customer": {
+        "firstName": "Charlotte",
+        "id": "3464-ae44-4242-ad3f",
+        "lastName": "Rust",
+        "phone": "+44-1"
+        },
+        "leg": {
+        "agencyId": "CoolSharing",
+        "arrivalDelay": 10,
+        "departureDelay": 8,
+        "distance": 9.7,
+        "fare": {},
+        "from": {
+            "lat": 48.7,
+            "lon": 8.38,
+            "name": "Karlsruhe Restaurant",
+            "stopCode": "rest23",
+            "stopId": "9876",
+            "additionalProp1": {}
+        },
+        "legGeometry": {
+            "points": "48.7,8.38,48.71,8.39,48.72,8.39",
+            "additionalProp1": {}
+        },
+        "route": "string",
+        "routeLongName": "tohome",
+        "routeShortName": "to my home location",
+        "to": {
+            "lat": 48.72,
+            "lon": 8.39,
+            "name": "homeofme",
+            "stopCode": "xhome",
+            "stopId": "8887",
+            "additionalProp1": {}
+        },
+        "additionalProp1": {}
+        },
+        "state": "NEW",
+        "id": "c12c-d45d-1165-ad42",
+        "meta": {},
+        "terms": "string",
+        "token": {
+        "meta": {},
+        "validityDuration": {}
+        }
+    },
+    {
+        "customer": {
+        "firstName": "Peter",
+        "id": "6534-2324-2314-ad3f",
+        "lastName": "Smith",
+        "phone": "+44-0"
+        },
+        "leg": {
+        "agencyId": "TaxiKa",
+        "arrivalDelay": 5,
+        "departureDelay": 3,
+        "distance": 11.4,
+        "fare": {},
+        "from": {
+            "lat": 49.0,
+            "lon": 8.4,
+            "name": "Karlsruhe zoo",
+            "stopCode": "zooka",
+            "stopId": "1234",
+            "additionalProp1": {}
+        },
+        "legGeometry": {
+            "points": "49.0,8.4,49.01,8.41,49.02,8.39",
+            "additionalProp1": {}
+        },
+        "route": "string",
+        "routeLongName": "toBusiness",
+        "routeShortName": "to my current meeting",
+        "to": {
+            "lat": 49.02,
+            "lon": 8.3,
+            "name": "company X",
+            "stopCode": "xcomp",
+            "stopId": "6542",
+            "additionalProp1": {}
+        },
+        "additionalProp1": {}
+        },
+        "state": "NEW",
+        "id": "aaff-9ec6-4711-ad3f",
+        "meta": {},
+        "terms": "string",
+        "token": {
+        "meta": {},
+        "validityDuration": {}
+        }
+    }
+]

--- a/mock_server/redoc.htm
+++ b/mock_server/redoc.htm
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>ReDoc rendered documentation of MaaS Alliance API Spec</title>
+    <!-- needed for adaptive design -->
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc spec-url='/booking/openapi.json'></redoc>
+    <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
+  </body>
+</html>

--- a/specifications/booking.yaml
+++ b/specifications/booking.yaml
@@ -40,7 +40,7 @@ paths:
       tags:
         - Listing
       parameters:
-        - name: from
+        - name: fromP
           description: 'User''s location in comma separated form e.g. 60.123,27.456'
           in: query
           required: true

--- a/specifications/booking.yaml
+++ b/specifications/booking.yaml
@@ -13,8 +13,8 @@ info:
     name: MaaS Alliance
     url: 'https://maas-alliance.eu/'
   license:
-    name: MIT
-    url: 'http://opensource.org/licenses/MIT'
+    name: Apache 2.0
+    url: 'https://github.com/maas-alliance/apis/blob/master/LICENSE'
   x-logo:
     url: "https://avatars2.githubusercontent.com/u/35918051?s=200&v=4"
     backgroundColor: "#FFFFFF"
@@ -45,7 +45,7 @@ paths:
         - Listing
       parameters:
         - name: _from
-          description: 'User''s location in comma separated form e.g. 60.123,27.456'
+          description: User's location in comma separated form e.g. 60.123,27.456
           in: query
           required: true
           schema:

--- a/specifications/booking.yaml
+++ b/specifications/booking.yaml
@@ -15,6 +15,10 @@ info:
   license:
     name: MIT
     url: 'http://opensource.org/licenses/MIT'
+  x-logo:
+    url: "https://avatars2.githubusercontent.com/u/35918051?s=200&v=4"
+    backgroundColor: "#FFFFFF"
+    altText: "MaaS Alliance logo"
 tags:
   - name: Booking
     description: >-
@@ -40,7 +44,7 @@ paths:
       tags:
         - Listing
       parameters:
-        - name: fromP
+        - name: _from
           description: 'User''s location in comma separated form e.g. 60.123,27.456'
           in: query
           required: true
@@ -84,6 +88,7 @@ paths:
   /bookings/:
     get:
       operationId: api.bookings_get
+      x-displayName: /bookings/
       description: Returns the `Booking` that has been created earlier
       tags:
         - Booking

--- a/specifications/booking.yaml
+++ b/specifications/booking.yaml
@@ -44,7 +44,7 @@ paths:
       tags:
         - Listing
       parameters:
-        - name: _from
+        - name: from
           description: User's location in comma separated form e.g. 60.123,27.456
           in: query
           required: true

--- a/specifications/staticfile.yaml
+++ b/specifications/staticfile.yaml
@@ -1,0 +1,32 @@
+openapi: 3.0.0
+servers: []
+info:
+  version: 0.1.0
+  title: Static file yaml
+  description: This is a API specification for the static files of the mock server
+  contact:
+    name: MaaS Alliance
+    url: 'https://maas-alliance.eu/'
+  license:
+    name: MIT
+    url: 'http://opensource.org/licenses/MIT'
+tags:
+  - name: Static
+    description: Deliver static files like redoc documentation
+    externalDocs:
+      description: idea found here
+      url: 'https://github.com/zalando/connexion/issues/441'
+paths:
+  /:
+    get:
+      operationId: api.static_redoc
+      description: HTML file with rendered OpenAPI reference.
+      tags:
+        - Static
+      responses:
+        '200':
+          description: Successfully loaded html page
+          content: 
+            text/html:
+              schema:
+                type: string

--- a/specifications/staticfile.yaml
+++ b/specifications/staticfile.yaml
@@ -8,8 +8,8 @@ info:
     name: MaaS Alliance
     url: 'https://maas-alliance.eu/'
   license:
-    name: MIT
-    url: 'http://opensource.org/licenses/MIT'
+    name: Apache 2.0
+    url: 'https://github.com/maas-alliance/apis/blob/master/LICENSE'
 tags:
   - name: Static
     description: Deliver static files like redoc documentation


### PR DESCRIPTION
- added a mock for /bookings GET by returning a manually crafted JSON example
- adapted the "from" parameter to "_from" for /bookings/options/ GET both in the booking.yaml and the handler definition to address a reserved word issue ==> we should fix that later 
- added ReDoc support by adding a staticfile.yaml and the corresponding handler to apiy.py + crerated redoc.htm; added a x-logo section in info: section to booking.yaml